### PR TITLE
pos variable is not in read_DataBlockChecksum

### DIFF
--- a/lib/decoder_stream.js
+++ b/lib/decoder_stream.js
@@ -218,6 +218,7 @@ Decoder.prototype.read_DataBlockData = function () {
 }
 
 Decoder.prototype.read_DataBlockChecksum = function () {
+	var pos = this.pos
 	if (this.descriptor.blockChecksum) {
 		if ( this.check_Size(SIZES.DATABLOCK_CHECKSUM) ) return true
 		var checksum = utils.readInt32LE(this.buffer, this.pos-4)


### PR DESCRIPTION
May be this is an easy mistake. 'pos' variable is not defined in this method. It is needed to revert from errors as other methods do.
