### PR TITLE
Allow other browserified packages to require lz4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "url": "git://github.com/pierrec/node-lz4.git"
   },
   "main": "./lib/lz4.js",
+  "browser": {
+    "./lib/utils.js": "./lib/utils-js.js"
+  },
   "bugs": {
     "url": "http://github.com/pierrec/node-lz4/issues"
   },


### PR DESCRIPTION
Added a browser field to package.json so that browserify can resolve the correct version of ./lib/utils.js on the browser. This simplifies the build process for packages requiring lz4.