### PR TITLE
Compression optimizations

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -3,6 +3,14 @@
  */
 var uint32 = require('cuint').UINT32
 
+if (!Math.imul) Math.imul = function imul(a, b) {
+	var ah = a >>> 16;
+	var al = a & 0xffff;
+	var bh = b >>> 16;
+	var bl = b & 0xffff;
+	return (al*bl + ((ah*bl + al*bh) << 16))|0;
+};
+
 /**
  * Decode a block. Assumptions: input contains all sequences of a 
  * chunk, output is large enough to receive the decoded data.
@@ -81,7 +89,7 @@ var
 ,	runBits 		= 8 - mlBits
 ,	runMask 		= (1 << runBits) - 1
 
-,	hasher 			= uint32(2654435761)
+,	hasher 			= 2654435761
 
 ,	hashTable		= new Int16Array(hashSize)
 ,	emptyTable		= new Int16Array(hashSize)
@@ -103,7 +111,6 @@ exports.compress = function (src, dst, sIdx, eIdx) {
 exports.compressDependent = compressBlock
 
 function compressBlock (src, dst, pos, sIdx, eIdx) {
-	var Hash = uint32() // Reusable unsigned 32 bits integer
 	var dpos = sIdx
 	var dlen = eIdx - sIdx
 	var anchor = 0
@@ -128,10 +135,7 @@ function compressBlock (src, dst, pos, sIdx, eIdx) {
 			var sequenceLowBits = src[pos+1]<<8 | src[pos]
 			var sequenceHighBits = src[pos+3]<<8 | src[pos+2]
 			// compute hash for the current sequence
-			var hash = Hash.fromBits(sequenceLowBits, sequenceHighBits)
-							.multiply(hasher)
-							.shiftr(hashShift)
-							.toNumber()
+			var hash = Math.imul(sequenceLowBits | (sequenceHighBits << 16), hasher) >>> hashShift
 			// get the position of the sequence matching the hash
 			// NB. since 2 different sequences may have the same hash
 			// it is double-checked below

--- a/lib/binding.js
+++ b/lib/binding.js
@@ -83,6 +83,9 @@ var
 
 ,	hasher 			= uint32(2654435761)
 
+,	hashTable		= new Int16Array(hashSize)
+,	emptyTable		= new Int16Array(hashSize)
+
 // CompressBound returns the maximum length of a lz4 block, given it's uncompressed length
 exports.compressBound = function (isize) {
 	return isize > maxInputSize
@@ -93,17 +96,13 @@ exports.compressBound = function (isize) {
 exports.compressHC = exports.compress
 
 exports.compress = function (src, dst, sIdx, eIdx) {
-	// V8 optimization: non sparse array with integers
-	var hashTable = new Array(hashSize)
-	for (var i = 0; i < hashSize; i++) {
-		hashTable[i] = 0
-	}
-	return compressBlock(src, dst, 0, hashTable, sIdx || 0, eIdx || dst.length)
+	hashTable.set(emptyTable)
+	return compressBlock(src, dst, 0, sIdx || 0, eIdx || dst.length)
 }
 
 exports.compressDependent = compressBlock
 
-function compressBlock (src, dst, pos, hashTable, sIdx, eIdx) {
+function compressBlock (src, dst, pos, sIdx, eIdx) {
 	var Hash = uint32() // Reusable unsigned 32 bits integer
 	var dpos = sIdx
 	var dlen = eIdx - sIdx


### PR DESCRIPTION
First commit uses typed arrays for the hashTable, second optimizes the hash computation itself.