### PR TITLE
Fix compressing a zero-sized stream

### DIFF
--- a/lib/encoder_stream.js
+++ b/lib/encoder_stream.js
@@ -196,6 +196,11 @@ Encoder.prototype._transform = function (data, encoding, done) {
 }
 
 Encoder.prototype._flush = function (done) {
+	if (this.first) {
+		this.push( this.header() )
+		this.first = false
+	}
+
 	if (this.length > 0) {
 		var buf = Buffer.concat(this.buffer, this.length)
 		this.buffer = []

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,11 +15,11 @@ exports.blockChecksum = function (d) {
 }
 
 exports.streamChecksum = function (d, c) {
-	if (d === null)
-		return XXH.digest(c)
-
 	if (c === null)
 		c = XXH.init(CHECKSUM_SEED)
+
+	if (d === null)
+		return XXH.digest(c)
 
 	XXH.update(c, d)
 


### PR DESCRIPTION
1. `_flush` now writes the header if it has not yet been written

2. fix `streamChecksum` usage of `c` argument before it was initialized
with a default value in case when both `c` and `d` are `null`.

Fixes: https://github.com/pierrec/node-lz4/issues/44

Sorry, no tests here — did not have time to figure out the best way for that, I am not familiar with the codebase. A testcase is given in #44.