### PR TITLE
utils: rename readInt32LE to readUInt32LE for clarity

### DIFF
--- a/lib/decoder_stream.js
+++ b/lib/decoder_stream.js
@@ -79,7 +79,7 @@ Decoder.prototype.read_MagicNumber = function () {
 	var pos = this.pos
 	if ( this.check_Size(SIZES.MAGIC) ) return true
 
-	var magic = utils.readInt32LE(this.buffer, pos)
+	var magic = utils.readUInt32LE(this.buffer, pos)
 
 	// Skippable chunk
 	if ( (magic & 0xFFFFFFF0) === lz4_static.MAGICNUMBER_SKIPPABLE ) {
@@ -101,7 +101,7 @@ Decoder.prototype.read_SkippableSize = function () {
 	var pos = this.pos
 	if ( this.check_Size(SIZES.SKIP_SIZE) ) return true
 	this.state = STATES.SKIP_DATA
-	this.skippableSize = utils.readInt32LE(this.buffer, pos)
+	this.skippableSize = utils.readUInt32LE(this.buffer, pos)
 }
 
 Decoder.prototype.read_Descriptor = function () {
@@ -164,7 +164,7 @@ Decoder.prototype.read_DictId = function () {
 	if (this.descriptor.dictId) {
 		var pos = this.pos
 		if ( this.check_Size(SIZES.DICTID) ) return true
-		this.dictId = utils.readInt32LE(this.buffer, pos)
+		this.dictId = utils.readUInt32LE(this.buffer, pos)
 	}
 
 	this.state = STATES.DESCRIPTOR_CHECKSUM
@@ -188,7 +188,7 @@ Decoder.prototype.read_DescriptorChecksum = function () {
 Decoder.prototype.read_DataBlockSize = function () {
 	var pos = this.pos
 	if ( this.check_Size(SIZES.DATABLOCK_SIZE) ) return true
-	var datablock_size = utils.readInt32LE(this.buffer, pos)
+	var datablock_size = utils.readUInt32LE(this.buffer, pos)
 	// Uncompressed
 	if ( datablock_size === lz4_static.EOS ) {
 		this.state = STATES.EOS
@@ -221,7 +221,7 @@ Decoder.prototype.read_DataBlockChecksum = function () {
 	var pos = this.pos
 	if (this.descriptor.blockChecksum) {
 		if ( this.check_Size(SIZES.DATABLOCK_CHECKSUM) ) return true
-		var checksum = utils.readInt32LE(this.buffer, this.pos-4)
+		var checksum = utils.readUInt32LE(this.buffer, this.pos-4)
 		var currentChecksum = utils.blockChecksum( this.dataBlock )
 		if (currentChecksum !== checksum) {
 			this.pos = pos
@@ -263,7 +263,7 @@ Decoder.prototype.read_EOS = function () {
 	if (this.descriptor.streamChecksum) {
 		var pos = this.pos
 		if ( this.check_Size(SIZES.EOS) ) return true
-		var checksum = utils.readInt32LE(this.buffer, pos)
+		var checksum = utils.readUInt32LE(this.buffer, pos)
 		if ( checksum !== utils.streamChecksum(null, this.currentStreamChecksum) ) {
 			this.pos = pos
 			this.emit_Error( 'Invalid stream checksum: ' + checksum.toString(16).toUpperCase() )

--- a/lib/utils-js.js
+++ b/lib/utils-js.js
@@ -24,8 +24,8 @@ exports.streamChecksum = function (d, c) {
 	return c.update(d)
 }
 
-// Provide simple readInt32LE as the Buffer ones from node and browserify are incompatible
-exports.readInt32LE = function (buffer, offset) {
+// Provide simple readUInt32LE as the Buffer ones from node and browserify are incompatible
+exports.readUInt32LE = function (buffer, offset) {
 	return (buffer[offset]) |
       (buffer[offset + 1] << 8) |
       (buffer[offset + 2] << 16) |

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,8 +26,8 @@ exports.streamChecksum = function (d, c) {
 	return c
 }
 
-// Provide simple readInt32LE as the Buffer ones from node and browserify are incompatible
-exports.readInt32LE = function (buffer, offset) {
+// Provide simple readUInt32LE as the Buffer ones from node and browserify are incompatible
+exports.readUInt32LE = function (buffer, offset) {
 	// this is nodejs Buffer.readUInt32LE() implementation...
 	return ((buffer[offset]) |
       (buffer[offset + 1] << 8) |


### PR DESCRIPTION
Rename `utils.readInt32LE` to `utils.readUInt32LE` for clarity, as that is actually performing an unsigned int32 read, as seen in the comment on the first line of the impl.

On a side note: I am not exactly sure what do you mean by «as the Buffer ones from node and browserify are incompatible» and suppose that it might have been just another int/uint mixup here. But I didn't touch that to be on the safe side.