### PR TITLE
reenable build web version on `npm i`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
   "scripts": {
     "test": "mocha",
     "install": "node-gyp rebuild",
-    "prepublishOnly": "./build.sh"
+    "prepublish": "./build.sh"
   }
 }


### PR DESCRIPTION
`prepublishOnly` skips the build.sh step. This brings back consistency with `npm i`  instruction in the README.