### PR TITLE
Fix compression level in compressHC

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,10 @@ In some cases, it is useful to be able to manipulate an LZ4 block instead of an 
 	* `output` (_Buffer_): encoded data block
 	* `startIdx` (_Number_): output buffer start index (optional, default=0)
 	* `endIdx` (_Number_): output buffer end index (optional, default=startIdx + output.length)
-* `LZ4#encodeBlockHC(input, output)` (_Number_) >0: compressed size, =0: not compressible
+* `LZ4#encodeBlockHC(input, output[, compressionLevel])` (_Number_) >0: compressed size, =0: not compressible
 	* `input` (_Buffer_): data block to encode with high compression
 	* `output` (_Buffer_): encoded data block
+	* `compressionLevel` (_Number_): compression level between 3 and 12 (optional, default=9)
 
 
 Blocks do not have any magic number and are provided as is. It is useful to store somewhere the size of the original input for decoding.

--- a/lib/binding/lz4_binding.cc
+++ b/lib/binding/lz4_binding.cc
@@ -74,7 +74,7 @@ Napi::Value LZ4CompressHC(const Napi::CallbackInfo& info) {
 
   Napi::Buffer<char> input = info[0].As<Napi::Buffer<char>>();
   Napi::Buffer<char> output = info[1].As<Napi::Buffer<char>>();
-  uint32_t compressionLevel = info[3].IsNumber() ? info[3].As<Napi::Number>().Uint32Value() : 9;
+  uint32_t compressionLevel = info[2].IsNumber() ? info[2].As<Napi::Number>().Uint32Value() : 9;
 
   Napi::Number result = Napi::Number::New(env, LZ4_compress_HC(input.Data(),
                                                          output.Data(),


### PR DESCRIPTION
The three arguments to `compressHC` are read from index 0, 1 and 3. It should be 0, 1 and 2.

The third argument was also undocumented, so I added it to the README.