### PR TITLE
Fix RangeError caused by streamSize in encoder

### DIFF
--- a/lib/encoder_stream.js
+++ b/lib/encoder_stream.js
@@ -67,10 +67,10 @@ inherits(Encoder, Transform)
 
 // Header = magic number + stream descriptor
 Encoder.prototype.headerSize = function () {
-	var streamSizeSize = this.options.streamSize ? SIZES.DESCRIPTOR : 0
+	var streamSizeSize = this.options.streamSize ? SIZES.SIZE : 0
 	var dictSize = this.options.dict ? SIZES.DICTID : 0
 
-	return SIZES.MAGIC + 1 + 1 + streamSizeSize + dictSize + 1
+	return SIZES.MAGIC + SIZES.DESCRIPTOR + streamSizeSize + dictSize + 1
 }
 
 Encoder.prototype.header = function () {
@@ -91,8 +91,8 @@ Encoder.prototype.header = function () {
 	this.state = STATES.SIZE
 	if (this.options.streamSize) {
 		//TODO only 32bits size supported
-		descriptor.writeInt32LE(0, pos)
-		descriptor.writeInt32LE(this.size, pos + 4)
+		descriptor.writeInt32LE(this.length, pos)
+		descriptor.writeInt32LE(0, pos + 4)
 		pos += SIZES.SIZE
 	}
 	this.state = STATES.DICTID

--- a/test/encode-test.js
+++ b/test/encode-test.js
@@ -45,6 +45,15 @@ describe('LZ4 encoder', function () {
       })
     })
 
+    describe('encoding with streamSize', function () {
+      it("should encode datag", function (done) {
+        var encoded = lz4.encode(decoded_data, { streamSize: true })
+
+        assert( compare(lz4.decode(encoded), decoded_data) )
+        done()
+      })
+    })
+
     // https://github.com/pierrec/node-lz4/issues/69
     describe('HC block compression', function () {
       it('decoded should match with original', function (done) {


### PR DESCRIPTION
Before this patch, there was an error in encoder when set `streamSize` to `true`:
```
Uncaught RangeError RangeError [ERR_OUT_OF_RANGE]: The value of "offset" is out of range. It must be >= 0 and <= 0. Received 2
    at __node_internal_captureLargerStackTrace (internal/errors:464:5)
    at NodeError (internal/errors:371:5)
    at boundsError (internal/buffer:86:9)
    at checkBounds (internal/buffer:55:5)
    at checkInt (internal/buffer:74:3)
    at writeU_Int32LE (internal/buffer:692:3)
    at writeInt32LE (internal/buffer:861:10)
```

This PR fixed the error and also added a simple test.